### PR TITLE
Fix viewport hook for SSR

### DIFF
--- a/src/hooks/useViewport.js
+++ b/src/hooks/useViewport.js
@@ -2,19 +2,23 @@ import { useState, useEffect } from 'react';
 
 export function useViewport() {
   const [dimensions, setDimensions] = useState({
-    width: window.innerWidth,
-    height: window.innerHeight,
+    width: 0,
+    height: 0,
   });
 
   useEffect(() => {
-    function handleResize() {
-      setDimensions({
-        width: window.innerWidth,
-        height: window.innerHeight,
-      });
+    if (typeof window !== 'undefined') {
+      function handleResize() {
+        setDimensions({
+          width: window.innerWidth,
+          height: window.innerHeight,
+        });
+      }
+
+      handleResize();
+      window.addEventListener('resize', handleResize);
+      return () => window.removeEventListener('resize', handleResize);
     }
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
   }, []);
 
   const { width, height } = dimensions;


### PR DESCRIPTION
## Summary
- avoid referencing `window` during `useState` initialization
- guard window access in `useEffect`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68434b4ccd3c8332a3ef060cfb2150e3